### PR TITLE
Add Windows clipboard support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ fn addPlatformDependencies(module: *std.Build.Module, target: std.Build.Resolved
     switch (target.result.os.tag) {
         .linux => {
             // Add wlr-data-control protocol implementation for Linux only
-            module.addCSourceFile(.{ 
+            module.addCSourceFile(.{
                 .file = b.path("src/wlr_protocol.c"),
                 .flags = &.{},
             });
@@ -18,6 +18,11 @@ fn addPlatformDependencies(module: *std.Build.Module, target: std.Build.Resolved
             module.link_libc = true;
             module.linkFramework("AppKit", .{});
             module.linkFramework("Foundation", .{});
+        },
+        .windows => {
+            module.link_libc = true;
+            module.linkSystemLibrary("user32", .{});
+            module.linkSystemLibrary("kernel32", .{});
         },
         else => {
             module.link_libc = true;
@@ -124,6 +129,33 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(macos_write_exe);
 
+    // Windows read example
+    const windows_read_exe = b.addExecutable(.{
+        .name = "windows-read",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/windows_read.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "clipboard", .module = clipboard_mod },
+            },
+        }),
+    });
+    b.installArtifact(windows_read_exe);
+
+    // Windows write example
+    const windows_write_exe = b.addExecutable(.{
+        .name = "windows-write",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/windows_write.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "clipboard", .module = clipboard_mod },
+            },
+        }),
+    });
+    b.installArtifact(windows_write_exe);
 
     // Run commands
     const run_wayland_read_cmd = b.addRunArtifact(wayland_read_exe);
@@ -157,7 +189,15 @@ pub fn build(b: *std.Build) void {
     const run_macos_write_step = b.step("run-macos-write", "Write text to clipboard via macOS");
     run_macos_write_step.dependOn(&run_macos_write_cmd.step);
 
+    const run_windows_read_cmd = b.addRunArtifact(windows_read_exe);
+    if (b.args) |args| run_windows_read_cmd.addArgs(args);
+    const run_windows_read_step = b.step("run-windows-read", "Run the Windows clipboard reader");
+    run_windows_read_step.dependOn(&run_windows_read_cmd.step);
 
+    const run_windows_write_cmd = b.addRunArtifact(windows_write_exe);
+    if (b.args) |args| run_windows_write_cmd.addArgs(args);
+    const run_windows_write_step = b.step("run-windows-write", "Write text to clipboard via Windows");
+    run_windows_write_step.dependOn(&run_windows_write_cmd.step);
 
     // Tests
     const lib_tests = b.addTest(.{

--- a/examples/windows_read.zig
+++ b/examples/windows_read.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const clipboard = @import("clipboard");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.log.info("Windows Clipboard Reader (45 second test)", .{});
+    std.log.info("Reading clipboard every second...", .{});
+    std.log.info("", .{});
+
+    var count: u32 = 0;
+    while (count < 45) : (count += 1) {
+        // Try to get clipboard data with automatic format detection
+        var data = clipboard.readClipboardData(allocator) catch |err| {
+            switch (err) {
+                clipboard.ClipboardError.NoData => {
+                    std.log.info("[{}] Clipboard is empty", .{count});
+                },
+                clipboard.ClipboardError.UnsupportedPlatform => {
+                    std.log.info("[{}] Error: Not running on Windows", .{count});
+                    return;
+                },
+                else => {
+                    std.log.info("[{}] Error reading clipboard: {}", .{ count, err });
+                },
+            }
+            std.Thread.sleep(1000 * std.time.ns_per_ms);
+            continue;
+        };
+        defer data.deinit();
+
+        // Display based on format
+        switch (data.format) {
+            .text => {
+                const text = try data.asText();
+                const display_text = if (text.len > 60) text[0..57] ++ "..." else text;
+                std.log.info("[{}] Text: {s}", .{ count, display_text });
+            },
+            .html => {
+                const html = data.data;
+                const display_html = if (html.len > 60) html[0..57] ++ "..." else html;
+                std.log.info("[{}] HTML ({} bytes): {s}", .{ count, html.len, display_html });
+            },
+            .image => {
+                std.log.info("[{}] Image: {} bytes", .{ count, data.data.len });
+            },
+            .rtf => {
+                std.log.info("[{}] RTF: {} bytes", .{ count, data.data.len });
+            },
+        }
+
+        std.Thread.sleep(1000 * std.time.ns_per_ms);
+    }
+}

--- a/examples/windows_write.zig
+++ b/examples/windows_write.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const clipboard = @import("clipboard");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const test_text = "Hello from Windows clipboard! 🪟";
+
+    std.log.info("Windows Clipboard Writer", .{});
+    std.log.info("Writing text to clipboard: {s}", .{test_text});
+
+    try clipboard.writeClipboardText(allocator, test_text);
+
+    std.log.info("Success! Text written to clipboard.", .{});
+
+    // Verify by reading it back
+    var data = try clipboard.readClipboardData(allocator);
+    defer data.deinit();
+
+    if (data.format == .text) {
+        const read_text = try data.asText();
+        std.log.info("Verification: Read back '{s}'", .{read_text});
+        if (std.mem.eql(u8, test_text, read_text)) {
+            std.log.info("✓ Write and read verification successful!", .{});
+        } else {
+            std.log.err("✗ Read text doesn't match written text", .{});
+        }
+    } else {
+        std.log.err("Unexpected format when reading back: {}", .{data.format});
+    }
+}

--- a/src/backends/windows.zig
+++ b/src/backends/windows.zig
@@ -1,0 +1,337 @@
+const std = @import("std");
+const clipboard = @import("../clipboard.zig");
+const windows = std.os.windows;
+
+const user32 = struct {
+    extern "user32" fn OpenClipboard(hWndNewOwner: ?windows.HWND) callconv(.winapi) windows.BOOL;
+    extern "user32" fn CloseClipboard() callconv(.winapi) windows.BOOL;
+    extern "user32" fn EmptyClipboard() callconv(.winapi) windows.BOOL;
+    extern "user32" fn GetClipboardData(uFormat: c_uint) callconv(.winapi) ?windows.HANDLE;
+    extern "user32" fn SetClipboardData(uFormat: c_uint, hMem: ?windows.HANDLE) callconv(.winapi) ?windows.HANDLE;
+    extern "user32" fn IsClipboardFormatAvailable(format: c_uint) callconv(.winapi) windows.BOOL;
+    extern "user32" fn EnumClipboardFormats(format: c_uint) callconv(.winapi) c_uint;
+    extern "user32" fn GetClipboardFormatNameW(format: c_uint, lpszFormatName: [*]u16, cchMaxCount: c_int) callconv(.winapi) c_int;
+    extern "user32" fn RegisterClipboardFormatW(lpszFormat: [*:0]const u16) callconv(.winapi) c_uint;
+};
+
+const kernel32 = struct {
+    extern "kernel32" fn GlobalAlloc(uFlags: c_uint, dwBytes: usize) callconv(.winapi) ?windows.HANDLE;
+    extern "kernel32" fn GlobalFree(hMem: ?windows.HANDLE) callconv(.winapi) ?windows.HANDLE;
+    extern "kernel32" fn GlobalLock(hMem: ?windows.HANDLE) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn GlobalUnlock(hMem: ?windows.HANDLE) callconv(.winapi) windows.BOOL;
+    extern "kernel32" fn GlobalSize(hMem: ?windows.HANDLE) callconv(.winapi) usize;
+};
+
+const CF_TEXT = 1;
+const CF_BITMAP = 2;
+const CF_DIB = 8;
+const CF_UNICODETEXT = 13;
+const CF_HDROP = 15;
+
+const GMEM_MOVEABLE = 0x0002;
+const GMEM_ZEROINIT = 0x0040;
+
+var cf_html: c_uint = 0;
+var cf_rtf: c_uint = 0;
+
+pub const PlatformType = enum {
+    windows,
+};
+
+pub fn detectPlatform() PlatformType {
+    return .windows;
+}
+
+fn ensureCustomFormats() void {
+    if (cf_html == 0) {
+        const html_name = std.unicode.utf8ToUtf16LeStringLiteral("HTML Format");
+        cf_html = user32.RegisterClipboardFormatW(html_name);
+    }
+    if (cf_rtf == 0) {
+        const rtf_name = std.unicode.utf8ToUtf16LeStringLiteral("Rich Text Format");
+        cf_rtf = user32.RegisterClipboardFormatW(rtf_name);
+    }
+}
+
+pub const ClipboardBackend = struct {
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) !ClipboardBackend {
+        ensureCustomFormats();
+        return ClipboardBackend{
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *ClipboardBackend) void {
+        _ = self;
+    }
+
+    pub fn read(self: *ClipboardBackend, format: clipboard.ClipboardFormat) !clipboard.ClipboardData {
+        if (user32.OpenClipboard(null) == 0) {
+            return clipboard.ClipboardError.ReadFailed;
+        }
+        defer _ = user32.CloseClipboard();
+
+        const cf_format = switch (format) {
+            .text => CF_UNICODETEXT,
+            .image => CF_DIB,
+            .html => cf_html,
+            .rtf => cf_rtf,
+        };
+
+        if (cf_format == 0) {
+            return clipboard.ClipboardError.UnsupportedPlatform;
+        }
+
+        const handle = user32.GetClipboardData(cf_format) orelse {
+            return clipboard.ClipboardError.NoData;
+        };
+
+        const ptr = kernel32.GlobalLock(handle) orelse {
+            return clipboard.ClipboardError.ReadFailed;
+        };
+        defer _ = kernel32.GlobalUnlock(handle);
+
+        const size = kernel32.GlobalSize(handle);
+        if (size == 0) {
+            return clipboard.ClipboardError.NoData;
+        }
+
+        switch (format) {
+            .text => {
+                const utf16_ptr = @as([*]const u16, @ptrCast(@alignCast(ptr)));
+                const utf16_len = std.mem.indexOfScalar(u16, utf16_ptr[0..size/2], 0) orelse size/2;
+                const utf16_slice = utf16_ptr[0..utf16_len];
+
+                const utf8_data = std.unicode.utf16LeToUtf8Alloc(self.allocator, utf16_slice) catch {
+                    return clipboard.ClipboardError.InvalidData;
+                };
+
+                return clipboard.ClipboardData{
+                    .data = utf8_data,
+                    .format = format,
+                    .allocator = self.allocator,
+                };
+            },
+            .image => {
+                const data = self.allocator.alloc(u8, size) catch {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer self.allocator.free(data);
+
+                const src_bytes = @as([*]const u8, @ptrCast(ptr));
+                @memcpy(data, src_bytes[0..size]);
+
+                return clipboard.ClipboardData{
+                    .data = data,
+                    .format = format,
+                    .allocator = self.allocator,
+                };
+            },
+            .html, .rtf => {
+                const src_ptr = @as([*]const u8, @ptrCast(ptr));
+                const actual_size = std.mem.indexOfScalar(u8, src_ptr[0..size], 0) orelse size;
+
+                const data = self.allocator.alloc(u8, actual_size) catch {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer self.allocator.free(data);
+
+                @memcpy(data, src_ptr[0..actual_size]);
+
+                return clipboard.ClipboardData{
+                    .data = data,
+                    .format = format,
+                    .allocator = self.allocator,
+                };
+            },
+        }
+    }
+
+    pub fn write(self: *ClipboardBackend, data: []const u8, format: clipboard.ClipboardFormat) !void {
+        _ = self;
+
+        if (user32.OpenClipboard(null) == 0) {
+            return clipboard.ClipboardError.WriteFailed;
+        }
+        defer _ = user32.CloseClipboard();
+
+        if (user32.EmptyClipboard() == 0) {
+            return clipboard.ClipboardError.WriteFailed;
+        }
+
+        switch (format) {
+            .text => {
+                const utf16_len = std.unicode.calcUtf16LeLen(data) catch {
+                    return clipboard.ClipboardError.InvalidData;
+                };
+
+                const handle = kernel32.GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, (utf16_len + 1) * 2) orelse {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer _ = kernel32.GlobalFree(handle);
+
+                const ptr = kernel32.GlobalLock(handle) orelse {
+                    _ = kernel32.GlobalFree(handle);
+                    return clipboard.ClipboardError.WriteFailed;
+                };
+                defer _ = kernel32.GlobalUnlock(handle);
+
+                const utf16_ptr = @as([*]u16, @ptrCast(@alignCast(ptr)));
+                _ = std.unicode.utf8ToUtf16Le(utf16_ptr[0..utf16_len], data) catch {
+                    return clipboard.ClipboardError.InvalidData;
+                };
+                utf16_ptr[utf16_len] = 0;
+
+                if (user32.SetClipboardData(CF_UNICODETEXT, handle) == null) {
+                    return clipboard.ClipboardError.WriteFailed;
+                }
+            },
+            .image => {
+                const handle = kernel32.GlobalAlloc(GMEM_MOVEABLE, data.len) orelse {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer _ = kernel32.GlobalFree(handle);
+
+                const ptr = kernel32.GlobalLock(handle) orelse {
+                    _ = kernel32.GlobalFree(handle);
+                    return clipboard.ClipboardError.WriteFailed;
+                };
+                defer _ = kernel32.GlobalUnlock(handle);
+
+                const dest_ptr = @as([*]u8, @ptrCast(ptr));
+                @memcpy(dest_ptr, data);
+
+                if (user32.SetClipboardData(CF_DIB, handle) == null) {
+                    return clipboard.ClipboardError.WriteFailed;
+                }
+            },
+            .html => {
+                ensureCustomFormats();
+                if (cf_html == 0) {
+                    return clipboard.ClipboardError.UnsupportedPlatform;
+                }
+
+                const handle = kernel32.GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, data.len + 1) orelse {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer _ = kernel32.GlobalFree(handle);
+
+                const ptr = kernel32.GlobalLock(handle) orelse {
+                    _ = kernel32.GlobalFree(handle);
+                    return clipboard.ClipboardError.WriteFailed;
+                };
+                defer _ = kernel32.GlobalUnlock(handle);
+
+                const dest_ptr = @as([*]u8, @ptrCast(ptr));
+                @memcpy(dest_ptr, data);
+                dest_ptr[data.len] = 0;
+
+                if (user32.SetClipboardData(cf_html, handle) == null) {
+                    return clipboard.ClipboardError.WriteFailed;
+                }
+            },
+            .rtf => {
+                ensureCustomFormats();
+                if (cf_rtf == 0) {
+                    return clipboard.ClipboardError.UnsupportedPlatform;
+                }
+
+                const handle = kernel32.GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, data.len + 1) orelse {
+                    return clipboard.ClipboardError.OutOfMemory;
+                };
+                errdefer _ = kernel32.GlobalFree(handle);
+
+                const ptr = kernel32.GlobalLock(handle) orelse {
+                    _ = kernel32.GlobalFree(handle);
+                    return clipboard.ClipboardError.WriteFailed;
+                };
+                defer _ = kernel32.GlobalUnlock(handle);
+
+                const dest_ptr = @as([*]u8, @ptrCast(ptr));
+                @memcpy(dest_ptr, data);
+                dest_ptr[data.len] = 0;
+
+                if (user32.SetClipboardData(cf_rtf, handle) == null) {
+                    return clipboard.ClipboardError.WriteFailed;
+                }
+            },
+        }
+    }
+
+    pub fn clear(self: *ClipboardBackend) !void {
+        _ = self;
+
+        if (user32.OpenClipboard(null) == 0) {
+            return clipboard.ClipboardError.WriteFailed;
+        }
+        defer _ = user32.CloseClipboard();
+
+        if (user32.EmptyClipboard() == 0) {
+            return clipboard.ClipboardError.WriteFailed;
+        }
+    }
+
+    pub fn processEvents(self: *ClipboardBackend) void {
+        _ = self;
+    }
+};
+
+pub fn getClipboardDataAuto(allocator: std.mem.Allocator) !clipboard.ClipboardData {
+    var backend = try ClipboardBackend.init(allocator);
+    defer backend.deinit();
+
+    if (user32.OpenClipboard(null) == 0) {
+        return clipboard.ClipboardError.ReadFailed;
+    }
+    defer _ = user32.CloseClipboard();
+
+    if (user32.IsClipboardFormatAvailable(CF_UNICODETEXT) != 0) {
+        return backend.read(.text);
+    }
+
+    ensureCustomFormats();
+    if (cf_html != 0 and user32.IsClipboardFormatAvailable(cf_html) != 0) {
+        return backend.read(.html);
+    }
+
+    if (cf_rtf != 0 and user32.IsClipboardFormatAvailable(cf_rtf) != 0) {
+        return backend.read(.rtf);
+    }
+
+    if (user32.IsClipboardFormatAvailable(CF_DIB) != 0) {
+        return backend.read(.image);
+    }
+
+    return clipboard.ClipboardError.NoData;
+}
+
+pub fn getAvailableClipboardFormats(allocator: std.mem.Allocator) ![]clipboard.ClipboardFormat {
+    var formats = std.ArrayList(clipboard.ClipboardFormat).init(allocator);
+    defer formats.deinit();
+
+    if (user32.OpenClipboard(null) == 0) {
+        return clipboard.ClipboardError.ReadFailed;
+    }
+    defer _ = user32.CloseClipboard();
+
+    if (user32.IsClipboardFormatAvailable(CF_UNICODETEXT) != 0) {
+        try formats.append(.text);
+    }
+
+    if (user32.IsClipboardFormatAvailable(CF_DIB) != 0) {
+        try formats.append(.image);
+    }
+
+    ensureCustomFormats();
+    if (cf_html != 0 and user32.IsClipboardFormatAvailable(cf_html) != 0) {
+        try formats.append(.html);
+    }
+
+    if (cf_rtf != 0 and user32.IsClipboardFormatAvailable(cf_rtf) != 0) {
+        try formats.append(.rtf);
+    }
+
+    return formats.toOwnedSlice();
+}

--- a/src/clipboard.zig
+++ b/src/clipboard.zig
@@ -57,6 +57,7 @@ fn getBackendModule() type {
     return switch (builtin.os.tag) {
         .linux => @import("backends/linux.zig"),
         .macos => @import("backends/macos.zig"),
+        .windows => @import("backends/windows.zig"),
         else => @import("backends/fallback.zig"),
     };
 }


### PR DESCRIPTION
- Implement Windows backend using Win32 API (user32/kernel32)
- Support text, HTML, RTF, and DIB image formats
- Handle UTF-8/UTF-16 conversion for proper text encoding
- Add Windows examples for reading and writing clipboard
- Update build.zig to link Windows system libraries
- Compatible with Zig 0.15.1 calling conventions